### PR TITLE
Complex read

### DIFF
--- a/appgate/resource_appgate_condition.go
+++ b/appgate/resource_appgate_condition.go
@@ -171,13 +171,32 @@ func resourceAppgateConditionRead(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Failed to read Condition, %+v", err)
 	}
 	d.SetId(remoteCondition.Id)
+	d.Set("condition_id", remoteCondition.Id)
 	d.Set("name", remoteCondition.Name)
 	d.Set("notes", remoteCondition.Notes)
 	d.Set("tags", remoteCondition.Tags)
 	d.Set("expression", remoteCondition.Expression)
 	d.Set("repeat_schedules", remoteCondition.RepeatSchedules)
-	d.Set("remedy_methods", remoteCondition.RemedyMethods)
+	if remoteCondition.RemedyMethods != nil {
+		if err = d.Set("remedy_methods", flattenConditionRemedyMethods(*remoteCondition.RemedyMethods)); err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+func flattenConditionRemedyMethods(in []openapi.ConditionAllOfRemedyMethods) []map[string]interface{} {
+	var out = make([]map[string]interface{}, len(in), len(in))
+	for i, v := range in {
+		m := make(map[string]interface{})
+		m["type"] = v.Type
+		m["message"] = v.Message
+		m["claim_suffix"] = v.ClaimSuffix
+		m["provider_id"] = v.ProviderId
+
+		out[i] = m
+	}
+	return out
 }
 
 func resourceAppgateConditionUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/appgate/resource_appgate_condition_test.go
+++ b/appgate/resource_appgate_condition_test.go
@@ -35,6 +35,12 @@ func TestAccConditionBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.535570215", "terraform"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateCheck:  testAccEntitlementImportStateCheckFunc(1),
+			},
 		},
 	})
 }

--- a/appgate/resource_appgate_criteria_script.go
+++ b/appgate/resource_appgate_criteria_script.go
@@ -106,6 +106,10 @@ func resourceAppgateCriteriaScriptRead(d *schema.ResourceData, meta interface{})
 	}
 	d.SetId(criteraScript.Id)
 	d.Set("criteria_script_id", criteraScript.Id)
+	d.Set("name", criteraScript.Name)
+	d.Set("notes", criteraScript.Notes)
+	d.Set("tags", criteraScript.Tags)
+	d.Set("expression", criteraScript.Expression)
 
 	return nil
 }

--- a/appgate/resource_appgate_entitlement_test.go
+++ b/appgate/resource_appgate_entitlement_test.go
@@ -20,23 +20,23 @@ func TestAccEntitlementBasicPing(t *testing.T) {
 			{
 				Config: testAccCheckEntitlementBasicPing(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckExampleItemExists(resourceName),
+					testAccCheckEntitlementExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", "ping"),
 					resource.TestCheckResourceAttr(resourceName, "actions.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "conditions.#", "1"),
 
-					resource.TestCheckResourceAttr(resourceName, "actions.4206576320.action", "allow"),
-					resource.TestCheckResourceAttr(resourceName, "actions.4206576320.hosts.#", "5"),
-					resource.TestCheckResourceAttr(resourceName, "actions.4206576320.hosts.0", "10.0.0.1"),
-					resource.TestCheckResourceAttr(resourceName, "actions.4206576320.hosts.1", "10.0.0.0/24"),
-					resource.TestCheckResourceAttr(resourceName, "actions.4206576320.hosts.2", "hostname.company.com"),
-					resource.TestCheckResourceAttr(resourceName, "actions.4206576320.hosts.3", "dns://hostname.company.com"),
-					resource.TestCheckResourceAttr(resourceName, "actions.4206576320.hosts.4", "aws://security-group:accounting"),
-					resource.TestCheckResourceAttr(resourceName, "actions.4206576320.ports.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "actions.3805508908.action", "allow"),
+					resource.TestCheckResourceAttr(resourceName, "actions.3805508908.hosts.#", "5"),
+					resource.TestCheckResourceAttr(resourceName, "actions.3805508908.hosts.0", "10.0.0.1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.3805508908.hosts.1", "10.0.0.0/24"),
+					resource.TestCheckResourceAttr(resourceName, "actions.3805508908.hosts.2", "hostname.company.com"),
+					resource.TestCheckResourceAttr(resourceName, "actions.3805508908.hosts.3", "dns://hostname.company.com"),
+					resource.TestCheckResourceAttr(resourceName, "actions.3805508908.hosts.4", "aws://security-group:accounting"),
+					resource.TestCheckResourceAttr(resourceName, "actions.3805508908.ports.#", "0"),
 
-					resource.TestCheckResourceAttr(resourceName, "actions.4206576320.subtype", "icmp_up"),
-					resource.TestCheckResourceAttr(resourceName, "actions.4206576320.types.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "actions.4206576320.types.0", "0-16"),
+					resource.TestCheckResourceAttr(resourceName, "actions.3805508908.subtype", "icmp_up"),
+					resource.TestCheckResourceAttr(resourceName, "actions.3805508908.types.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.3805508908.types.0", "0-16"),
 
 					resource.TestCheckResourceAttr(resourceName, "app_shortcut.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "app_shortcut.1872821293.color_code", "5"),
@@ -53,10 +53,10 @@ func TestAccEntitlementBasicPing(t *testing.T) {
 				),
 			},
 			{
-				ResourceName: resourceName,
-				ImportState:  true,
-				// ImportStateVerify: true,
-				ImportStateCheck: testAccEntitlementImportStateCheckFunc(1),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateCheck:  testAccEntitlementImportStateCheckFunc(1),
 			},
 		},
 	})
@@ -135,7 +135,7 @@ resource "appgate_entitlement" "test_item" {
 `)
 }
 
-func testAccCheckExampleItemExists(resource string) resource.TestCheckFunc {
+func testAccCheckEntitlementExists(resource string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 		token := testAccProvider.Meta().(*Client).Token
 		api := testAccProvider.Meta().(*Client).API.EntitlementsApi

--- a/appgate/resource_appgate_policy.go
+++ b/appgate/resource_appgate_policy.go
@@ -211,6 +211,13 @@ func resourceAppgatePolicyRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("notes", policy.GetNotes())
 	d.Set("disabled", policy.GetDisabled())
 	d.Set("expression", policy.GetExpression())
+	d.Set("entitlements", policy.GetEntitlements())
+	d.Set("entitlement_links", policy.GetEntitlementLinks())
+	d.Set("ringfence_rule_links", policy.GetRingfenceRuleLinks())
+	d.Set("ringfence_rules", policy.GetRingfenceRules())
+	d.Set("tags", policy.GetTags())
+	d.Set("tamper_proofing", policy.GetTamperProofing())
+	d.Set("administrative_roles", policy.GetAdministrativeRoles())
 
 	return nil
 }

--- a/appgate/resource_appgate_policy_test.go
+++ b/appgate/resource_appgate_policy_test.go
@@ -28,7 +28,14 @@ func TestAccPolicyBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.2876187004", "api-created"),
 					resource.TestCheckResourceAttr(resourceName, "tags.535570215", "terraform"),
 					resource.TestCheckResourceAttr(resourceName, "tamper_proofing", "true"),
+					resource.TestCheckResourceAttr(resourceName, "ringfence_rule_links.1941342072", "developer"),
+					resource.TestCheckResourceAttr(resourceName, "entitlement_links.1941342072", "developer"),
 				),
+			},
+			{
+				ResourceName:     resourceName,
+				ImportState:      true,
+				ImportStateCheck: testAccCriteriaScripImportStateCheckFunc(1),
 			},
 		},
 	})
@@ -37,17 +44,24 @@ func TestAccPolicyBasic(t *testing.T) {
 func testAccCheckPolicyBasic() string {
 	return fmt.Sprintf(`
 resource "appgate_policy" "test_policy" {
-    name = "policy-test"
-    notes = "terraform policy notes"
-    tags = [
-      "terraform",
-      "api-created"
-    ]
-    disabled = false
+  name  = "policy-test"
+  notes = "terraform policy notes"
+  tags = [
+    "terraform",
+    "api-created"
+  ]
+  disabled = false
 
-    expression = <<-EOF
+  expression = <<-EOF
     return true;
   EOF
+  entitlement_links = [
+    "developer"
+  ]
+  ringfence_rule_links = [
+    "developer"
+  ]
+  tamper_proofing = true
 }
 `)
 }

--- a/appgate/resource_appgate_ringfence_rule.go
+++ b/appgate/resource_appgate_ringfence_rule.go
@@ -180,9 +180,29 @@ func resourceAppgateRingfenceRuleRead(d *schema.ResourceData, meta interface{}) 
 	}
 	d.Set("ringfence_rule_id", ringfenceRule.Id)
 	d.Set("name", ringfenceRule.Name)
+	d.Set("notes", ringfenceRule.Notes)
 	d.Set("tags", ringfenceRule.Tags)
-	d.Set("actions", ringfenceRule.Actions)
+	if ringfenceRule.Actions != nil {
+		if err = d.Set("actions", flattenRingfenceActions(ringfenceRule.Actions)); err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+func flattenRingfenceActions(in []openapi.RingfenceRuleAllOfActions) []map[string]interface{} {
+	var out = make([]map[string]interface{}, len(in), len(in))
+	for i, v := range in {
+		m := make(map[string]interface{})
+		m["protocol"] = v.Protocol
+		m["direction"] = v.Direction
+		m["action"] = v.Action
+		m["hosts"] = v.Hosts
+		m["ports"] = v.Ports
+		m["types"] = v.Types
+		out[i] = m
+	}
+	return out
 }
 
 func resourceAppgateRingfenceRuleUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/appgate/resource_appgate_ringfence_rule_test.go
+++ b/appgate/resource_appgate_ringfence_rule_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccRingfenceRuleBasic(t *testing.T) {
+func TestAccRingfenceRuleBasicICMP(t *testing.T) {
 	resourceName := "appgate_ringfence_rule.test_ringfence_rule"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -17,36 +17,37 @@ func TestAccRingfenceRuleBasic(t *testing.T) {
 		CheckDestroy: testAccCheckRingfenceRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckRingfenceRule(),
+				Config: testAccCheckRingfenceRuleICMP(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRingfenceRuleExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", "ringfence-rule-test"),
 					resource.TestCheckResourceAttr(resourceName, "notes", "Managed by terraform"),
 
 					resource.TestCheckResourceAttr(resourceName, "actions.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "actions.4182075683.action", "allow"),
-					resource.TestCheckResourceAttr(resourceName, "actions.4182075683.direction", "out"),
-					resource.TestCheckResourceAttr(resourceName, "actions.4182075683.hosts.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "actions.4182075683.hosts.0", "10.0.2.0/24"),
+					resource.TestCheckResourceAttr(resourceName, "actions.3319774903.action", "allow"),
+					resource.TestCheckResourceAttr(resourceName, "actions.3319774903.direction", "out"),
+					resource.TestCheckResourceAttr(resourceName, "actions.3319774903.hosts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.3319774903.hosts.0", "10.0.2.0/24"),
 
-					resource.TestCheckResourceAttr(resourceName, "actions.4182075683.ports.#", "3"),
-					resource.TestCheckResourceAttr(resourceName, "actions.4182075683.ports.0", "80"),
-					resource.TestCheckResourceAttr(resourceName, "actions.4182075683.ports.1", "443"),
-					resource.TestCheckResourceAttr(resourceName, "actions.4182075683.ports.2", "1024-2048"),
-					resource.TestCheckResourceAttr(resourceName, "actions.4182075683.protocol", "icmp"),
-					resource.TestCheckResourceAttr(resourceName, "actions.4182075683.types.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "actions.4182075683.types.0", "0-255"),
+					resource.TestCheckResourceAttr(resourceName, "actions.3319774903.protocol", "icmp"),
+					resource.TestCheckResourceAttr(resourceName, "actions.3319774903.types.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.3319774903.ports.#", "0"),
 
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.2876187004", "api-created"),
 					resource.TestCheckResourceAttr(resourceName, "tags.535570215", "terraform"),
 				),
 			},
+			{
+				ResourceName:     resourceName,
+				ImportState:      true,
+				ImportStateCheck: testAccCriteriaScripImportStateCheckFunc(1),
+			},
 		},
 	})
 }
 
-func testAccCheckRingfenceRule() string {
+func testAccCheckRingfenceRuleICMP() string {
 	return fmt.Sprintf(`
 resource "appgate_ringfence_rule" "test_ringfence_rule" {
     name = "ringfence-rule-test"
@@ -63,18 +64,77 @@ resource "appgate_ringfence_rule" "test_ringfence_rule" {
         hosts = [
           "10.0.2.0/24"
         ]
-
-        ports = [
-          "80",
-          "443",
-          "1024-2048"
-        ]
-
         types = [
           "0-255"
         ]
-
       }
+}
+`)
+}
+
+func TestAccRingfenceRuleBasicTCP(t *testing.T) {
+	resourceName := "appgate_ringfence_rule.test_ringfence_rule_tcp"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRingfenceRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckRingfenceRuleTCP(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRingfenceRuleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", "ringfence-rule-test-tcp"),
+					resource.TestCheckResourceAttr(resourceName, "notes", "Managed by terraform"),
+
+					resource.TestCheckResourceAttr(resourceName, "actions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.4218684535.action", "allow"),
+					resource.TestCheckResourceAttr(resourceName, "actions.4218684535.direction", "out"),
+					resource.TestCheckResourceAttr(resourceName, "actions.4218684535.hosts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.4218684535.hosts.0", "10.0.2.0/24"),
+
+					resource.TestCheckResourceAttr(resourceName, "actions.4218684535.protocol", "tcp"),
+					resource.TestCheckResourceAttr(resourceName, "actions.4218684535.types.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "actions.4218684535.ports.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "actions.4218684535.ports.0", "80"),
+					resource.TestCheckResourceAttr(resourceName, "actions.4218684535.ports.1", "443"),
+					resource.TestCheckResourceAttr(resourceName, "actions.4218684535.ports.2", "1024-2048"),
+
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.2876187004", "api-created"),
+					resource.TestCheckResourceAttr(resourceName, "tags.535570215", "terraform"),
+				),
+			},
+			{
+				ResourceName:     resourceName,
+				ImportState:      true,
+				ImportStateCheck: testAccCriteriaScripImportStateCheckFunc(1),
+			},
+		},
+	})
+}
+func testAccCheckRingfenceRuleTCP() string {
+	return fmt.Sprintf(`
+resource "appgate_ringfence_rule" "test_ringfence_rule_tcp" {
+    name = "ringfence-rule-test-tcp"
+    tags = [
+      "terraform",
+      "api-created"
+    ]
+    actions {
+      protocol = "tcp"
+      action   = "allow"
+      direction = "out"
+
+      hosts = [
+        "10.0.2.0/24"
+      ]
+
+      ports = [
+        "80",
+        "443",
+        "1024-2048"
+      ]
+    }
 }
 `)
 }


### PR DESCRIPTION
correctly read all attributes for resources:

- entitlement
- condition
- criteria script
- policy
- ringfence rule

previous this was missing, which caused incomplete state in the statefile. This will improve usage when running terraform import on these resources,