### PR TITLE
Resource device script

### DIFF
--- a/appgate/data_source_appgate_entitlement_script.go
+++ b/appgate/data_source_appgate_entitlement_script.go
@@ -12,15 +12,15 @@ func dataSourceEntitlementScript() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceAppgateEntitlementScriptRead,
 		Schema: map[string]*schema.Schema{
-			"entitlement script_id": {
+			"entitlement_script_id": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ConflictsWith: []string{"entitlement script_name"},
+				ConflictsWith: []string{"entitlement_script_name"},
 			},
-			"entitlement script_name": {
+			"entitlement_script_name": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ConflictsWith: []string{"entitlement script_id"},
+				ConflictsWith: []string{"entitlement_script_id"},
 			},
 		},
 	}
@@ -30,11 +30,11 @@ func dataSourceAppgateEntitlementScriptRead(d *schema.ResourceData, meta interfa
 	token := meta.(*Client).Token
 	api := meta.(*Client).API.EntitlementScriptsApi
 
-	entitlementScriptID, iok := d.GetOk("entitlement script_id")
-	entitlementScriptName, nok := d.GetOk("entitlement script_name")
+	entitlementScriptID, iok := d.GetOk("entitlement_script_id")
+	entitlementScriptName, nok := d.GetOk("entitlement_script_name")
 
 	if !iok && !nok {
-		return fmt.Errorf("please provide one of entitlement script_id or entitlement script_name attributes")
+		return fmt.Errorf("please provide one of entitlement_script_id or entitlement_script_name attributes")
 	}
 	var reqErr error
 	var entitlementScript *openapi.EntitlementScript

--- a/appgate/provider.go
+++ b/appgate/provider.go
@@ -55,6 +55,7 @@ func Provider() terraform.ResourceProvider {
 			"appgate_policy":             resourceAppgatePolicy(),
 			"appgate_criteria_script":    resourceAppgateCriteriaScript(),
 			"appgate_entitlement_script": resourceAppgateEntitlementScript(),
+			"appgate_device_script":      resourceAppgateDeviceScript(),
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/appgate/resource_appgate_device_script.go
+++ b/appgate/resource_appgate_device_script.go
@@ -1,0 +1,229 @@
+package appgate
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"time"
+
+	"github.com/appgate/terraform-provider-appgate/client/v12/openapi"
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAppgateDeviceScript() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAppgateDeviceScriptCreate,
+		Read:   resourceAppgateDeviceScriptRead,
+		Update: resourceAppgateDeviceScriptUpdate,
+		Delete: resourceAppgateDeviceScriptDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		SchemaVersion: 1,
+		Schema: map[string]*schema.Schema{
+
+			"device_script_id": {
+				Type:        schema.TypeString,
+				Description: "ID of the object.",
+				Computed:    true,
+			},
+
+			"name": {
+				Type:        schema.TypeString,
+				Description: "Name of the object.",
+				Required:    true,
+			},
+
+			"notes": {
+				Type:        schema.TypeString,
+				Description: "Notes for the object. Used for documentation purposes.",
+				Default:     DefaultDescription,
+				Optional:    true,
+			},
+
+			"tags": {
+				Type:        schema.TypeSet,
+				Description: "Array of tags.",
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+
+			"filename": {
+				Type:        schema.TypeString,
+				Description: "The name of the file to be downloaded as to the client devices.",
+				Required:    true,
+			},
+
+			"file": {
+				Type:          schema.TypeString,
+				Description:   "Path to the Device Script binary.",
+				Optional:      true,
+				ConflictsWith: []string{"content"},
+			},
+
+			"content": {
+				Type:          schema.TypeString,
+				Description:   "The Device Script content.",
+				Optional:      true,
+				ConflictsWith: []string{"file"},
+			},
+
+			"checksum_sha256": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAppgateDeviceScriptCreate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Creating Device script: %s", d.Get("name").(string))
+	token := meta.(*Client).Token
+	api := meta.(*Client).API.DeviceScriptsApi
+	args := openapi.NewDeviceScriptWithDefaults()
+	args.Id = uuid.New().String()
+	args.SetName(d.Get("name").(string))
+	args.SetNotes(d.Get("notes").(string))
+	args.SetFilename(d.Get("filename").(string))
+	args.SetTags(schemaExtractTags(d))
+
+	content, err := getDeviceScriptContent(d)
+	if err != nil {
+		return err
+	}
+
+	encoded := base64.StdEncoding.EncodeToString(content)
+	args.SetFile(encoded)
+
+	request := api.DeviceScriptsPost(context.TODO())
+	request = request.DeviceScript(*args)
+
+	deviceScript, _, err := request.Authorization(token).Execute()
+	if err != nil {
+		return fmt.Errorf("Could not create Device script %+v", prettyPrintAPIError(err))
+	}
+
+	d.SetId(deviceScript.Id)
+	d.Set("device_script_id", deviceScript.Id)
+
+	return resourceAppgateDeviceScriptRead(d, meta)
+}
+
+func getDeviceScriptContent(d *schema.ResourceData) ([]byte, error) {
+	var content []byte
+	if v, ok := d.GetOk("file"); ok {
+		path := v.(string)
+		file, err := os.Open(path)
+		if err != nil {
+			return nil, fmt.Errorf("Error opening device script file (%s): %s", path, err)
+		}
+		defer func() {
+			err := file.Close()
+			if err != nil {
+				log.Printf("[WARN] Error closing device script file (%s): %s", path, err)
+			}
+		}()
+		reader := bufio.NewReader(file)
+		content, err = ioutil.ReadAll(reader)
+		if err != nil {
+			return nil, fmt.Errorf("Error reading device script file (%s): %s", path, err)
+		}
+
+	} else if v, ok := d.GetOk("content"); ok {
+		content = []byte(v.(string))
+	}
+	return content, nil
+}
+
+func resourceAppgateDeviceScriptRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Reading Device script id: %+v", d.Id())
+	token := meta.(*Client).Token
+	api := meta.(*Client).API.DeviceScriptsApi
+	ctx := context.TODO()
+	request := api.DeviceScriptsIdGet(ctx, d.Id())
+	deviceScript, _, err := request.Authorization(token).Execute()
+	if err != nil {
+		// TODO check if 404
+		d.SetId("")
+		return fmt.Errorf("Failed to read Device script, %+v", err)
+	}
+	d.SetId(deviceScript.Id)
+	d.Set("device_script_id", deviceScript.Id)
+	d.Set("name", deviceScript.Name)
+	d.Set("notes", deviceScript.Notes)
+	d.Set("tags", deviceScript.Tags)
+	d.Set("checksum_sha256", deviceScript.GetChecksumSha256())
+
+	return nil
+}
+
+func resourceAppgateDeviceScriptUpdate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Updating Device script: %s", d.Get("name").(string))
+	log.Printf("[DEBUG] Updating Device script id: %+v", d.Id())
+	token := meta.(*Client).Token
+	api := meta.(*Client).API.DeviceScriptsApi
+	ctx := context.TODO()
+	request := api.DeviceScriptsIdGet(ctx, d.Id())
+	originalDeviceScript, _, err := request.Authorization(token).Execute()
+	if err != nil {
+		return fmt.Errorf("Failed to read Device script while updating, %+v", err)
+	}
+
+	if d.HasChange("name") {
+		originalDeviceScript.SetName(d.Get("name").(string))
+	}
+
+	if d.HasChange("notes") {
+		originalDeviceScript.SetNotes(d.Get("notes").(string))
+	}
+
+	if d.HasChange("tags") {
+		originalDeviceScript.SetTags(schemaExtractTags(d))
+	}
+
+	if d.HasChange("file") || d.HasChange("content") {
+		content, err := getDeviceScriptContent(d)
+		if err != nil {
+			return err
+		}
+
+		encoded := base64.StdEncoding.EncodeToString(content)
+		originalDeviceScript.SetFile(encoded)
+	}
+
+	req := api.DeviceScriptsIdPut(ctx, d.Id())
+	req = req.DeviceScript(originalDeviceScript)
+	_, _, err = req.Authorization(token).Execute()
+	if err != nil {
+		return fmt.Errorf("Could not update Device script %+v", prettyPrintAPIError(err))
+	}
+	return resourceAppgateDeviceScriptRead(d, meta)
+}
+
+func resourceAppgateDeviceScriptDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Delete Device script: %s", d.Get("name").(string))
+	log.Printf("[DEBUG] Reading Device script id: %+v", d.Id())
+	token := meta.(*Client).Token
+	api := meta.(*Client).API.DeviceScriptsApi
+
+	request := api.DeviceScriptsIdDelete(context.TODO(), d.Id())
+
+	_, err := request.Authorization(token).Execute()
+	if err != nil {
+		return fmt.Errorf("Could not delete Device script %+v", prettyPrintAPIError(err))
+	}
+	d.SetId("")
+	return nil
+}

--- a/appgate/resource_appgate_device_script_test.go
+++ b/appgate/resource_appgate_device_script_test.go
@@ -1,0 +1,108 @@
+package appgate
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDeviceScriptBasic(t *testing.T) {
+	resourceName := "appgate_device_script.test_device_script"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDeviceScriptDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDeviceScriptBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeviceScriptExists(resourceName),
+
+					resource.TestCheckResourceAttr(resourceName, "checksum_sha256", "74443048b52bf2be3b0f003a8f37592551d316c6c7c28b1a110ee6f879ef4130"),
+					resource.TestCheckResourceAttr(resourceName, "content", "#!/usr/bin/env bash\necho \"hello world\"\n"),
+
+					resource.TestCheckResourceAttr(resourceName, "filename", "acceptance_script.sh"),
+					resource.TestCheckResourceAttr(resourceName, "name", "device_script_one"),
+					resource.TestCheckResourceAttr(resourceName, "notes", "Managed by terraform"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.2876187004", "api-created"),
+					resource.TestCheckResourceAttr(resourceName, "tags.535570215", "terraform"),
+				),
+			},
+			{
+				ResourceName:     resourceName,
+				ImportState:      true,
+				ImportStateCheck: testAccDeviceScriptImportStateCheckFunc(1),
+			},
+		},
+	})
+}
+
+func testAccCheckDeviceScriptBasic() string {
+	return fmt.Sprintf(`
+resource "appgate_device_script" "test_device_script" {
+  name     = "device_script_one"
+  filename = "acceptance_script.sh"
+  content  = <<-EOF
+#!/usr/bin/env bash
+echo "hello world"
+EOF
+  tags = [
+    "terraform",
+    "api-created"
+  ]
+}
+`)
+}
+
+func testAccCheckDeviceScriptExists(resource string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		token := testAccProvider.Meta().(*Client).Token
+		api := testAccProvider.Meta().(*Client).API.DeviceScriptsApi
+
+		rs, ok := state.RootModule().Resources[resource]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resource)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Record ID is set")
+		}
+
+		_, _, err := api.DeviceScriptsIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
+		if err != nil {
+			return fmt.Errorf("error fetching device script with resource %s. %s", resource, err)
+		}
+		return nil
+	}
+}
+
+func testAccCheckDeviceScriptDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "appgate_device_script" {
+			continue
+		}
+
+		token := testAccProvider.Meta().(*Client).Token
+		api := testAccProvider.Meta().(*Client).API.DeviceScriptsApi
+
+		_, _, err := api.DeviceScriptsIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
+		if err == nil {
+			return fmt.Errorf("Device script still exists, %+v", err)
+		}
+	}
+	return nil
+}
+
+func testAccDeviceScriptImportStateCheckFunc(expectedStates int) resource.ImportStateCheckFunc {
+	return func(s []*terraform.InstanceState) error {
+		if len(s) != expectedStates {
+			return fmt.Errorf("expected %d states, got %d: %+v", expectedStates, len(s), s)
+		}
+		return nil
+	}
+}

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -427,3 +427,17 @@ resource "appgate_criteria_script" "test_criteria_script" {
     "api-created"
   ]
 }
+
+
+resource "appgate_device_script" "example_device_script" {
+  name     = "device_script_name"
+  filename = "script.sh"
+  content  = <<-EOF
+#!/usr/bin/env bash
+echo "hello world"
+EOF
+  tags = [
+    "terraform",
+    "api-created"
+  ]
+}

--- a/website/docs/r/device_script.markdown
+++ b/website/docs/r/device_script.markdown
@@ -12,6 +12,8 @@ Create a new Device Script.
 
 ## Example Usage
 
+
+### Inline content script
 ```hcl
 
 resource "appgate_device_script" "example_device_script" {
@@ -25,6 +27,18 @@ EOF
     "terraform",
     "api-created"
   ]
+}
+
+```
+
+### Upload device script from file path
+
+```hcl
+
+resource "appgate_device_script" "example_device_script" {
+  name     = "device_script_name"
+  filename = "script.sh"
+  file     = "/path/to/file/script.sh"
 }
 
 ```

--- a/website/docs/r/device_script.markdown
+++ b/website/docs/r/device_script.markdown
@@ -1,0 +1,54 @@
+---
+layout: "appgate"
+page_title: "APPGATE: appgate_device_script"
+sidebar_current: "docs-appgate-resource-device_script"
+description: |-
+   Create a new Device Script.
+---
+
+# appgate_device_script
+
+Create a new Device Script.
+
+## Example Usage
+
+```hcl
+
+resource "appgate_device_script" "example_device_script" {
+  name     = "device_script_name"
+  filename = "script.sh"
+  content  = <<-EOF
+#!/usr/bin/env bash
+echo "hello world"
+EOF
+  tags = [
+    "terraform",
+    "api-created"
+  ]
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+
+* `filename`: (Required) The name of the file to be downloaded as to the client devices.
+* `file`: (Optional) The Device Script binary path, conflicts with `content`.
+* `content`: (Optional) The Device Script content, conflicts with `file`.
+* `name`: (Required) Name of the object.
+* `notes`: (Optional) Notes for the object. Used for documentation purposes.
+* `tags`: (Optional) Array of tags.
+
+
+
+
+
+## Import
+
+Instances can be imported using the `id`, e.g.
+
+```
+$ terraform import appgate_device_script d3131f83-10d1-4abc-ac0b-7349538e8300
+```


### PR DESCRIPTION
new resource, appgate device script  

example: 

```hcl
resource "appgate_device_script" "example_device_script" {
  name     = "device_script_name"
  filename = "script.sh"
  content  = <<-EOF
#!/usr/bin/env bash
echo "hello world"
EOF
  tags = [
    "terraform",
    "api-created"
  ]
}
```