### PR TITLE
support condition with remedy action displayMessage

### DIFF
--- a/appgate/resource_appgate_condition.go
+++ b/appgate/resource_appgate_condition.go
@@ -291,11 +291,11 @@ func readRemedyMethodsFromConfig(methods []interface{}) ([]openapi.ConditionAllO
 			r.SetMessage(v.(string))
 		}
 
-		if v, ok := raw["claim_suffix"]; ok {
+		if v, ok := raw["claim_suffix"]; ok && len(v.(string)) > 0 {
 			r.SetClaimSuffix(v.(string))
 		}
 
-		if v, ok := raw["provider_id"]; ok {
+		if v, ok := raw["provider_id"]; ok && len(v.(string)) > 0 {
 			r.SetProviderId(v.(string))
 		}
 		result = append(result, r)

--- a/appgate/resource_appgate_condition_test.go
+++ b/appgate/resource_appgate_condition_test.go
@@ -24,7 +24,9 @@ func TestAccConditionBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "expression", "return true;"),
 					resource.TestCheckResourceAttr(resourceName, "notes", "Managed by terraform"),
 
-					resource.TestCheckResourceAttr(resourceName, "remedy_methods.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "remedy_methods.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "remedy_methods.0.message", "This resoure requires you to enter your password again"),
+					resource.TestCheckResourceAttr(resourceName, "remedy_methods.0.type", "DisplayMessage"),
 
 					resource.TestCheckResourceAttr(resourceName, "repeat_schedules.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "repeat_schedules.2107984292", "13:32"),
@@ -60,7 +62,10 @@ resource "appgate_condition" "test_condition" {
       "1h",
       "13:32"
     ]
-
+    remedy_methods {
+        type        = "DisplayMessage"
+        message     = "This resoure requires you to enter your password again"
+    }
 }
 `)
 }

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -383,12 +383,10 @@ EOF
     "13:32"
   ]
 
-  # remedy_methods {
-  #   type        = "DisplayMessage"
-  #   message     = "This resoure requires you to enter your password again"
-  #   claim_suffix = "test"
-  #   provider_id  = "4c07bc67-57ea-42dd-b702-c2d6c45419fc"
-  # }
+  remedy_methods {
+    type        = "DisplayMessage"
+    message     = "This resoure requires you to enter your password again"
+  }
 
 }
 


### PR DESCRIPTION
fields claimSuffix and providerId is only required when type != DisplayMessage.
