### PR TITLE
env variable APPGATE_HTTP_DEBUG

### DIFF
--- a/appgate/config.go
+++ b/appgate/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	Provider string
 	Insecure bool
 	Timeout  int
+	Debug    bool
 }
 
 // Client is the appgate API client.
@@ -62,7 +63,7 @@ func (c *Config) Client() (*Client, error) {
 			"Accept": fmt.Sprintf("application/vnd.appgate.peer-v%d+json", Version),
 		},
 		UserAgent: "Appgate-TerraformProvider/1.0.0/go",
-		Debug:     true,
+		Debug:     c.Debug,
 		Servers: []openapi.ServerConfiguration{
 			{
 				URL:         c.URL,

--- a/appgate/provider.go
+++ b/appgate/provider.go
@@ -34,6 +34,11 @@ func Provider() terraform.ResourceProvider {
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("APPGATE_INSECURE", true),
 			},
+			"debug": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("APPGATE_HTTP_DEBUG", false),
+			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"appgate_appliance":               dataSourceAppgateAppliance(),
@@ -77,6 +82,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		Provider: d.Get("provider").(string),
 		Insecure: d.Get("insecure").(bool),
 		Timeout:  20,
+		Debug:    d.Get("debug").(bool),
 	}
 	return config.Client()
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -85,3 +85,5 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
   it can also be sourced from the `APPGATE_PROVIDER` environment variables.
 
 * `insecure` - (Optional) Whether server should be accessed without verifying the TLS certificate. As the name suggests this is insecure and should not be used beyond experiments, accessing local (non-production) GHE instance etc. There is a number of ways to obtain trusted certificate for free, e.g. from Let's Encrypt. Such trusted certificate does not require this option to be enabled. Defaults to `true`.
+
+* `debug` - (Optional) Whether HTTP request should be displayed in debug mode, combine with [TF_LOG](https://www.terraform.io/docs/internals/debugging.html) Defaults to `false`.


### PR DESCRIPTION
toggle HTTP request/response in debug mode.

Usage:
```
export TF_LOG=DEBUG
export APPGATE_HTTP_DEBUG=true
```