### PR TITLE
Saml idp bug fix

### DIFF
--- a/appgate/identity_provider.go
+++ b/appgate/identity_provider.go
@@ -122,7 +122,7 @@ func identityProviderIPPoolSchema() map[string]*schema.Schema {
 func identityProviderClaimsSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"claim_mappings": {
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Optional: true,
 			Computed: true,
 			Elem: &schema.Resource{
@@ -149,7 +149,7 @@ func identityProviderClaimsSchema() map[string]*schema.Schema {
 			},
 		},
 		"on_demand_claim_mappings": {
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Optional: true,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
@@ -378,13 +378,13 @@ func readProviderFromConfig(d *schema.ResourceData, provider openapi.IdentityPro
 		provider.SetBlockLocalDnsRequests(v.(bool))
 	}
 	if v, ok := d.GetOk("claim_mappings"); ok {
-		claims := readIdentityProviderClaimMappingFromConfig(v.([]interface{}))
+		claims := readIdentityProviderClaimMappingFromConfig(v.(*schema.Set).List())
 		if len(claims) > 0 {
 			provider.SetClaimMappings(claims)
 		}
 	}
 	if v, ok := d.GetOk("on_demand_claim_mappings"); ok {
-		claims := readIdentityProviderOnDemandClaimMappingFromConfig(v.([]interface{}))
+		claims := readIdentityProviderOnDemandClaimMappingFromConfig(v.(*schema.Set).List())
 		if len(claims) > 0 {
 			provider.SetOnDemandClaimMappings(claims)
 		}
@@ -423,7 +423,7 @@ func readIdentityProviderClaimMappingFromConfig(input []interface{}) []map[strin
 		if v, ok := claim["list"]; ok {
 			c["list"] = v.(bool)
 		}
-		if v, ok := claim["encrypt"]; ok {
+		if v, ok := claim["encrypted"]; ok {
 			c["encrypt"] = v.(bool)
 		}
 		claims = append(claims, c)
@@ -495,8 +495,8 @@ func flattenIdentityProviderClaimsMappning(claims []map[string]interface{}) []ma
 		if v, ok := claim["list"]; ok {
 			row["list"] = v.(bool)
 		}
-		if v, ok := claim["encrypted"]; ok {
-			row["list"] = v.(bool)
+		if v, ok := claim["encrypt"]; ok {
+			row["encrypted"] = v.(bool)
 		}
 		out[i] = row
 	}

--- a/appgate/resource_appgate_identity_provider_saml.go
+++ b/appgate/resource_appgate_identity_provider_saml.go
@@ -278,12 +278,12 @@ func resourceAppgateSamlProviderRuleUpdate(d *schema.ResourceData, meta interfac
 	}
 	if d.HasChange("claim_mappings") {
 		_, v := d.GetChange("claim_mappings")
-		claims := readIdentityProviderClaimMappingFromConfig(v.([]interface{}))
+		claims := readIdentityProviderClaimMappingFromConfig(v.(*schema.Set).List())
 		originalSamlProvider.SetClaimMappings(claims)
 	}
 	if d.HasChange("on_demand_claim_mappings") {
 		_, v := d.GetChange("on_demand_claim_mappings")
-		claims := readIdentityProviderOnDemandClaimMappingFromConfig(v.([]interface{}))
+		claims := readIdentityProviderOnDemandClaimMappingFromConfig(v.(*schema.Set).List())
 		originalSamlProvider.SetOnDemandClaimMappings(claims)
 	}
 

--- a/appgate/resource_appgate_identity_provider_saml_test.go
+++ b/appgate/resource_appgate_identity_provider_saml_test.go
@@ -21,65 +21,65 @@ func TestAccSamlIdentityProviderBasic(t *testing.T) {
 				Config: testAccCheckSamlIdentityProviderBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSamlIdentityProviderExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "notes", "Managed by terraform"),
 					resource.TestCheckResourceAttr(resourceName, "admin_provider", "true"),
-					resource.TestCheckResourceAttr(resourceName, "audience", "Company Appgate SDP"),
-					resource.TestCheckResourceAttr(resourceName, "block_local_dns_requests", "true"),
-					resource.TestCheckResourceAttr(resourceName, "claim_mappings.#", "6"),
-					resource.TestCheckResourceAttr(resourceName, "claim_mappings.0.attribute_name", "objectGUID"),
-					resource.TestCheckResourceAttr(resourceName, "claim_mappings.0.claim_name", "userId"),
-					resource.TestCheckResourceAttr(resourceName, "claim_mappings.0.encrypted", "false"),
-					resource.TestCheckResourceAttr(resourceName, "claim_mappings.0.list", "false"),
-					resource.TestCheckResourceAttr(resourceName, "claim_mappings.1.attribute_name", "sAMAccountName"),
-					resource.TestCheckResourceAttr(resourceName, "claim_mappings.1.claim_name", "username"),
-					resource.TestCheckResourceAttr(resourceName, "claim_mappings.1.encrypted", "false"),
-					resource.TestCheckResourceAttr(resourceName, "claim_mappings.1.list", "false"),
-					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2.attribute_name", "givenName"),
-					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2.claim_name", "firstName"),
-					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2.encrypted", "false"),
-					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2.list", "false"),
-					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3.attribute_name", "sn"),
-					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3.claim_name", "lastName"),
-					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3.encrypted", "false"),
-					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3.list", "false"),
-					resource.TestCheckResourceAttr(resourceName, "claim_mappings.4.attribute_name", "mail"),
-					resource.TestCheckResourceAttr(resourceName, "claim_mappings.4.claim_name", "emails"),
-					resource.TestCheckResourceAttr(resourceName, "claim_mappings.4.encrypted", "false"),
-					resource.TestCheckResourceAttr(resourceName, "claim_mappings.4.list", "true"),
-					resource.TestCheckResourceAttr(resourceName, "claim_mappings.5.attribute_name", "memberOf"),
-					resource.TestCheckResourceAttr(resourceName, "claim_mappings.5.claim_name", "groups"),
-					resource.TestCheckResourceAttr(resourceName, "claim_mappings.5.encrypted", "false"),
-					resource.TestCheckResourceAttr(resourceName, "claim_mappings.5.list", "true"),
-					resource.TestCheckResourceAttr(resourceName, "decryption_key", ""),
-					resource.TestCheckResourceAttr(resourceName, "default", "false"),
-					resource.TestCheckResourceAttr(resourceName, "dns_search_domains.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "dns_search_domains.0", "internal.company.com"),
+					resource.TestCheckResourceAttr(resourceName, "ip_pool_v4", "f572b4ab-7963-4a90-9e5a-3bf033bfe2cc"),
+					resource.TestCheckResourceAttr(resourceName, "ip_pool_v6", "6935b379-205d-4fdd-847f-a0b5f14aff53"),
 					resource.TestCheckResourceAttr(resourceName, "dns_servers.#", "3"),
 					resource.TestCheckResourceAttr(resourceName, "dns_servers.0", "172.17.18.19"),
 					resource.TestCheckResourceAttr(resourceName, "dns_servers.1", "192.100.111.31"),
 					resource.TestCheckResourceAttr(resourceName, "dns_servers.2", "192.100.111.32"),
-					resource.TestCheckResourceAttr(resourceName, "inactivity_timeout_minutes", "0"),
-					resource.TestCheckResourceAttr(resourceName, "ip_pool_v4", "f572b4ab-7963-4a90-9e5a-3bf033bfe2cc"),
-					resource.TestCheckResourceAttr(resourceName, "ip_pool_v6", "6935b379-205d-4fdd-847f-a0b5f14aff53"),
+					resource.TestCheckResourceAttr(resourceName, "dns_search_domains.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "dns_search_domains.0", "internal.company.com"),
+					resource.TestCheckResourceAttr(resourceName, "redirect_url", "https://saml.company.com"),
 					resource.TestCheckResourceAttr(resourceName, "issuer", "http://adfs-test.company.com/adfs/services/trust"),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "audience", "Company Appgate SDP"),
 					resource.TestCheckResourceAttrSet(resourceName, "provider_certificate"),
-					resource.TestCheckResourceAttr(resourceName, "notes", "Managed by terraform"),
+					resource.TestCheckResourceAttr(resourceName, "decryption_key", ""),
+					resource.TestCheckResourceAttr(resourceName, "block_local_dns_requests", "true"),
+					resource.TestCheckResourceAttr(resourceName, "default", "false"), //depreciated feature
+					resource.TestCheckResourceAttr(resourceName, "inactivity_timeout_minutes", "0"),
 					resource.TestCheckResourceAttr(resourceName, "on_boarding_two_factor.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "on_boarding_two_factor.0.device_limit_per_user", "6"),
 					resource.TestCheckResourceAttr(resourceName, "on_boarding_two_factor.0.message", "welcome"),
 					resource.TestCheckResourceAttr(resourceName, "on_boarding_two_factor.0.mfa_provider_id", "3ae98d53-c520-437f-99e4-451f936e6d2c"),
-					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.0.claim_name", "antiVirusIsRunning"),
-					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.0.command", "fileSize"),
-					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.0.parameters.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.0.parameters.0.args", ""),
-					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.0.parameters.0.name", ""),
-					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.0.parameters.0.path", "/usr/bin/python3"),
-					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.0.platform", "desktop.windows.all"),
-					resource.TestCheckResourceAttr(resourceName, "redirect_url", "https://saml.company.com"),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.535570215", "terraform"),
 					resource.TestCheckResourceAttr(resourceName, "type", "Saml"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.#", "6"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3889155743.attribute_name", "givenName"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3889155743.claim_name", "firstName"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3889155743.encrypted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3889155743.list", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3609328139.attribute_name", "mail"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3609328139.claim_name", "emails"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3609328139.encrypted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3609328139.list", "true"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2429955231.attribute_name", "memberOf"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2429955231.claim_name", "groups"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2429955231.encrypted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2429955231.list", "true"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2440191359.attribute_name", "objectGUID"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2440191359.claim_name", "userId"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2440191359.encrypted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2440191359.list", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.633464825.attribute_name", "sAMAccountName"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.633464825.claim_name", "username"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.633464825.encrypted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.633464825.list", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2672447578.attribute_name", "sn"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2672447578.claim_name", "lastName"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2672447578.encrypted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2672447578.list", "false"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.3657813038.claim_name", "antiVirusIsRunning"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.3657813038.command", "fileSize"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.3657813038.parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.3657813038.parameters.0.args", ""),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.3657813038.parameters.0.name", ""),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.3657813038.parameters.0.path", "/usr/bin/python3"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.3657813038.platform", "desktop.windows.all"),
 				),
 			},
 			{
@@ -88,124 +88,624 @@ func TestAccSamlIdentityProviderBasic(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateCheck:  testAccSamlIdentityProviderImportStateCheckFunc(1),
 			},
+			{
+				Config: testAccCheckSamlIdentityProviderUpdates(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSamlIdentityProviderExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName), //Name cannot be changed
+					resource.TestCheckResourceAttr(resourceName, "notes", "Test note change"),
+					resource.TestCheckResourceAttr(resourceName, "admin_provider", "false"),
+					resource.TestCheckResourceAttr(resourceName, "ip_pool_v4", "f572b4ab-7963-4a90-9e5a-3bf033bfe2cc"),
+					resource.TestCheckResourceAttr(resourceName, "dns_servers.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "dns_servers.0", "172.17.18.21"),
+					resource.TestCheckResourceAttr(resourceName, "dns_servers.1", "192.100.111.31"),
+					resource.TestCheckResourceAttr(resourceName, "dns_servers.2", "192.100.111.32"),
+					resource.TestCheckResourceAttr(resourceName, "dns_servers.3", "172.17.18.20"),
+					resource.TestCheckResourceAttr(resourceName, "dns_search_domains.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "dns_search_domains.0", "update.company.com"),
+					resource.TestCheckResourceAttr(resourceName, "dns_search_domains.1", "test.company.com"),
+					resource.TestCheckResourceAttr(resourceName, "redirect_url", "https://saml.update.company.com"),
+					resource.TestCheckResourceAttr(resourceName, "issuer", "http://adfs-test.update.company.com/adfs/services/trust"),
+					resource.TestCheckResourceAttr(resourceName, "audience", "Company Appgate SDP - Update"),
+					resource.TestCheckResourceAttrSet(resourceName, "provider_certificate"), //Write custom function to check for content of certificate?
+					resource.TestCheckResourceAttr(resourceName, "decryption_key", ""),
+					resource.TestCheckResourceAttr(resourceName, "block_local_dns_requests", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default", "false"), //depreciated feature
+					resource.TestCheckResourceAttr(resourceName, "inactivity_timeout_minutes", "5"),
+					resource.TestCheckResourceAttr(resourceName, "on_boarding_two_factor.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "on_boarding_two_factor.0.device_limit_per_user", "4"),
+					resource.TestCheckResourceAttr(resourceName, "on_boarding_two_factor.0.message", "change"),
+					resource.TestCheckResourceAttr(resourceName, "on_boarding_two_factor.0.mfa_provider_id", "3ae98d53-c520-437f-99e4-451f936e6d2c"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.721265975", "terraformm"),
+					resource.TestCheckResourceAttr(resourceName, "tags.1478979999", "change"),
+					resource.TestCheckResourceAttr(resourceName, "type", "Saml"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.#", "7"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2440191359.attribute_name", "objectGUID"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2440191359.claim_name", "userId"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2440191359.encrypted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2440191359.list", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.633464825.attribute_name", "sAMAccountName"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.633464825.claim_name", "username"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.633464825.encrypted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.633464825.list", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3889155743.attribute_name", "givenName"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3889155743.claim_name", "firstName"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3889155743.encrypted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3889155743.list", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2672447578.attribute_name", "sn"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2672447578.claim_name", "lastName"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2672447578.encrypted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2672447578.list", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3609328139.attribute_name", "mail"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3609328139.claim_name", "emails"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3609328139.encrypted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3609328139.list", "true"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2429955231.attribute_name", "memberOf"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2429955231.claim_name", "groups"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2429955231.encrypted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2429955231.list", "true"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.4086349502.attribute_name", "test"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.4086349502.claim_name", "test"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.4086349502.encrypted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.4086349502.list", "false"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.3657813038.claim_name", "antiVirusIsRunning"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.3657813038.command", "fileSize"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.3657813038.parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.3657813038.parameters.0.args", ""),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.3657813038.parameters.0.name", ""),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.3657813038.parameters.0.path", "/usr/bin/python3"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.3657813038.platform", "desktop.windows.all"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.2606747736.claim_name", "testing"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.2606747736.command", "serviceRunning"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.2606747736.parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.2606747736.parameters.0.args", ""),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.2606747736.parameters.0.name", "test.exe"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.2606747736.parameters.0.path", ""),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.2606747736.platform", "desktop.windows.all"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.3619765172.claim_name", "anotherOne"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.3619765172.command", "serviceRunning"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.3619765172.parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.3619765172.parameters.0.args", ""),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.3619765172.parameters.0.name", "test2.exe"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.3619765172.parameters.0.path", ""),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.3619765172.platform", "desktop.windows.all"),
+				),
+			},
+			{
+				Config: testAccCheckSamlIdentityProviderClaimMoveAndDelete(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSamlIdentityProviderExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "notes", "Test note change"),
+					resource.TestCheckResourceAttr(resourceName, "admin_provider", "false"),
+					resource.TestCheckResourceAttr(resourceName, "ip_pool_v4", "f572b4ab-7963-4a90-9e5a-3bf033bfe2cc"),
+					resource.TestCheckResourceAttr(resourceName, "dns_servers.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "dns_servers.0", "192.100.111.32"),
+					resource.TestCheckResourceAttr(resourceName, "dns_servers.1", "172.17.18.20"),
+					resource.TestCheckResourceAttr(resourceName, "dns_search_domains.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "dns_search_domains.0", "test.company.com"),
+					resource.TestCheckResourceAttr(resourceName, "redirect_url", "https://saml.update.company.com"),
+					resource.TestCheckResourceAttr(resourceName, "issuer", "http://adfs-test.update.company.com/adfs/services/trust"),
+					resource.TestCheckResourceAttr(resourceName, "audience", "Company Appgate SDP - Update"),
+					resource.TestCheckResourceAttrSet(resourceName, "provider_certificate"), //Write custom function to check for content of certificate?
+					resource.TestCheckResourceAttr(resourceName, "decryption_key", ""),
+					resource.TestCheckResourceAttr(resourceName, "block_local_dns_requests", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default", "false"), //depreciated feature
+					resource.TestCheckResourceAttr(resourceName, "inactivity_timeout_minutes", "5"),
+					resource.TestCheckResourceAttr(resourceName, "on_boarding_two_factor.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "on_boarding_two_factor.0.device_limit_per_user", "4"),
+					resource.TestCheckResourceAttr(resourceName, "on_boarding_two_factor.0.message", "change"),
+					resource.TestCheckResourceAttr(resourceName, "on_boarding_two_factor.0.mfa_provider_id", "3ae98d53-c520-437f-99e4-451f936e6d2c"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "type", "Saml"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.#", "5"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2672447578.attribute_name", "sn"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2672447578.claim_name", "lastName"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2672447578.encrypted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2672447578.list", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.633464825.attribute_name", "sAMAccountName"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.633464825.claim_name", "username"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.633464825.encrypted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.633464825.list", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3609328139.attribute_name", "mail"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3609328139.claim_name", "emails"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3609328139.encrypted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3609328139.list", "true"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3840649981.attribute_name", "test"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3840649981.claim_name", "test"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3840649981.encrypted", "true"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3840649981.list", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3889155743.attribute_name", "givenName"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3889155743.claim_name", "firstName"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3889155743.encrypted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3889155743.list", "false"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.3619765172.claim_name", "anotherOne"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.3619765172.command", "serviceRunning"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.3619765172.parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.3619765172.parameters.0.args", ""),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.3619765172.parameters.0.name", "test2.exe"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.3619765172.parameters.0.path", ""),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.3619765172.platform", "desktop.windows.all"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.2606747736.claim_name", "testing"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.2606747736.command", "serviceRunning"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.2606747736.parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.2606747736.parameters.0.args", ""),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.2606747736.parameters.0.name", "test.exe"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.2606747736.parameters.0.path", ""),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.2606747736.platform", "desktop.windows.all"),
+				),
+			},
+			{
+                // Make sure moving around claims results in an empty plan
+                Config: testAccCheckSamlIdentityProviderClaimMoves(rName),
+                Check: resource.ComposeTestCheckFunc(
+                    testAccCheckSamlIdentityProviderExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+                ),
+                ExpectNonEmptyPlan: false,
+            },
 		},
 	})
 }
 
 func testAccCheckSamlIdentityProviderBasic(rName string) string {
 	return fmt.Sprintf(`
-data "appgate_ip_pool" "ip_v6_pool" {
-  ip_pool_name = "default pool v6"
+	data "appgate_ip_pools" "ip_v6_pool" {
+	ip_pool_name = "default pool v6"
+	}
+
+	data "appgate_ip_pools" "ip_v4_pool" {
+	ip_pool_name = "default pool v4"
+	}
+	data "appgate_mfa_provider" "fido" {
+	mfa_provider_name = "Default FIDO2 Provider"
+	}
+	resource "appgate_saml_identity_provider" "saml_test_resource" {
+	name = "%s"
+
+	admin_provider = true
+	ip_pool_v4     = data.appgate_ip_pools.ip_v4_pool.id
+	ip_pool_v6     = data.appgate_ip_pools.ip_v6_pool.id
+	dns_servers = [
+		"172.17.18.19",
+		"192.100.111.31",
+		"192.100.111.32",
+	]
+	dns_search_domains = [
+		"internal.company.com"
+	]
+	redirect_url = "https://saml.company.com"
+	issuer       = "http://adfs-test.company.com/adfs/services/trust"
+	audience     = "Company Appgate SDP"
+
+
+	provider_certificate = <<-EOF
+	-----BEGIN CERTIFICATE-----
+	MIICZjCCAc+gAwIBAgIUT0AsBLRI7aKjaMTnH1N9J6eS+7EwDQYJKoZIhvcNAQEL
+	BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+	GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMDA5MjIxNDQ5MTZaFw0yMTA5
+	MjIxNDQ5MTZaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+	HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwgZ8wDQYJKoZIhvcNAQEB
+	BQADgY0AMIGJAoGBAOWp5CnfLvNpjeESzTg/B/1kG1BRdXtM00q59WPj7adZ5gq+
+	+Hr0mWEQ5GldgmXRE3HsXfv7hiq4RwX9h+qtRinwhSvtLquM54/Fpw+TYZl5N27m
+	ov8a04qqlo8c3BqXR5Vp+ohPVcXs2I21k5bUTh5XwHj4uiv8uxmKzk42WETbAgMB
+	AAGjUzBRMB0GA1UdDgQWBBSpc1YN7rgPiBrVPn0roGV+1B4ETDAfBgNVHSMEGDAW
+	gBSpc1YN7rgPiBrVPn0roGV+1B4ETDAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3
+	DQEBCwUAA4GBAMgxxBlfgH98ME7Es9xlV3HrurwG1p2gBvrrEACMtFNgtZE1vgck
+	jmhbc3t+Af9Dv9KBkaI6ZDl16uiptdpAv59wLgbVFgEPUJboRjhIaw5mPcMCeSDE
+	eIE/AV/qHWNEiLIMP5JO2FUbjpDCYtHkCOFDmv01e6rs86L3MQ8zF76T
+	-----END CERTIFICATE-----
+	EOF
+
+	block_local_dns_requests = true
+	on_boarding_two_factor {
+		mfa_provider_id       = data.appgate_mfa_provider.fido.id
+		device_limit_per_user = 6
+		message               = "welcome"
+	}
+	tags = [
+		"terraform",
+
+	]
+	claim_mappings {
+		attribute_name = "objectGUID"
+		claim_name     = "userId"
+		encrypted      = false
+		list           = false
+	}
+	claim_mappings {
+		attribute_name = "sAMAccountName"
+		claim_name     = "username"
+		encrypted      = false
+		list           = false
+	}
+	claim_mappings {
+		attribute_name = "givenName"
+		claim_name     = "firstName"
+		encrypted      = false
+		list           = false
+	}
+	claim_mappings {
+		attribute_name = "sn"
+		claim_name     = "lastName"
+		encrypted      = false
+		list           = false
+	}
+	claim_mappings {
+		attribute_name = "mail"
+		claim_name     = "emails"
+		encrypted      = false
+		list           = true
+	}
+	claim_mappings {
+		attribute_name = "memberOf"
+		claim_name     = "groups"
+		encrypted      = false
+		list           = true
+	}
+
+	on_demand_claim_mappings {
+		command    = "fileSize"
+		claim_name = "antiVirusIsRunning"
+		parameters {
+		path = "/usr/bin/python3"
+		}
+		platform = "desktop.windows.all"
+	}
+	}
+	`, rName)
 }
 
-data "appgate_ip_pool" "ip_v4_pool" {
-  ip_pool_name = "default pool v4"
+func testAccCheckSamlIdentityProviderUpdates(rName string) string {
+	return fmt.Sprintf(`
+	data "appgate_ip_pools" "ip_v6_pool" {
+	ip_pool_name = "default pool v6"
+	}
+
+	data "appgate_ip_pools" "ip_v4_pool" {
+	ip_pool_name = "default pool v4"
+	}
+	data "appgate_mfa_provider" "fido" {
+	mfa_provider_name = "Default FIDO2 Provider"
+	}
+	resource "appgate_saml_identity_provider" "saml_test_resource" {
+	name = "%s"
+	notes = "Test note change"
+	admin_provider = false
+	ip_pool_v4     = data.appgate_ip_pools.ip_v4_pool.id
+	dns_servers = [
+		"172.17.18.21",
+		"192.100.111.31",
+		"192.100.111.32",
+		"172.17.18.20"
+	]
+	dns_search_domains = [
+		"update.company.com",
+		"test.company.com"
+	]
+	redirect_url = "https://saml.update.company.com"
+	issuer       = "http://adfs-test.update.company.com/adfs/services/trust"
+	audience     = "Company Appgate SDP - Update"
+
+
+	provider_certificate = <<-EOF
+	-----BEGIN CERTIFICATE-----
+	MIICZjCCAc+gAwIBAgIUT0AsBLRI7aKjaMTnH1N9J6eS+7EwDQYJKoZIhvcNAQEL
+	BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+	GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMDA5MjIxNDQ5MTZaFw0yMTA5
+	MjIxNDQ5MTZaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+	HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwgZ8wDQYJKoZIhvcNAQEB
+	BQADgY0AMIGJAoGBAOWp5CnfLvNpjeESzTg/B/1kG1BRdXtM00q59WPj7adZ5gq+
+	+Hr0mWEQ5GldgmXRE3HsXfv7hiq4RwX9h+qtRinwhSvtLquM54/Fpw+TYZl5N27m
+	ov8a04qqlo8c3BqXR5Vp+ohPVcXs2I21k5bUTh5XwHj4uiv8uxmKzk42WETbAgMB
+	AAGjUzBRMB0GA1UdDgQWBBSpc1YN7rgPiBrVPn0roGV+1B4ETDAfBgNVHSMEGDAW
+	gBSpc1YN7rgPiBrVPn0roGV+1B4ETDAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3
+	DQEBCwUAA4GBAMgxxBlfgH98ME7Es9xlV3HrurwG1p2gBvrrEACMtFNgtZE1vgck
+	jmhbc3t+Af9Dv9KBkaI6ZDl16uiptdpAv59wLgbVFgEPUJboRjhIaw5mPcMCeSDE
+	eIE/AV/qHWNEiLIMP5JO2FUbjpDCYtHkCOFDmv01e6rs86L3MQ8zF76T
+	-----END CERTIFICATE-----
+	EOF
+
+	block_local_dns_requests = false
+	inactivity_timeout_minutes = 5
+
+	on_boarding_two_factor {
+		mfa_provider_id       = data.appgate_mfa_provider.fido.id
+		device_limit_per_user = 4
+		message               = "change"
+	}
+	tags = [
+		"terraformm",
+		"change"
+
+	]
+	claim_mappings {
+		attribute_name = "objectGUID"
+		claim_name     = "userId"
+		encrypted      = false
+		list           = false
+	}
+	claim_mappings {
+		attribute_name = "sAMAccountName"
+		claim_name     = "username"
+		encrypted      = false
+		list           = false
+	}
+	claim_mappings {
+		attribute_name = "givenName"
+		claim_name     = "firstName"
+		encrypted      = false
+		list           = false
+	}
+	claim_mappings {
+		attribute_name = "sn"
+		claim_name     = "lastName"
+		encrypted      = false
+		list           = false
+	}
+	claim_mappings {
+		attribute_name = "mail"
+		claim_name     = "emails"
+		encrypted      = false
+		list           = true
+	}
+	claim_mappings {
+		attribute_name = "memberOf"
+		claim_name     = "groups"
+		encrypted      = false
+		list           = true
+	}
+		claim_mappings {
+		attribute_name = "test"
+		claim_name     = "test"
+		encrypted      = false
+		list           = false
+	}
+	on_demand_claim_mappings {
+		command    = "fileSize"
+		claim_name = "antiVirusIsRunning"
+		parameters {
+		path = "/usr/bin/python3"
+		}
+		platform = "desktop.windows.all"
+	}
+	on_demand_claim_mappings {
+		command    = "serviceRunning"
+		claim_name = "testing"
+		parameters {
+		name = "test.exe"
+		}
+		platform = "desktop.windows.all"
+	}
+	on_demand_claim_mappings {
+		command    = "serviceRunning"
+		claim_name = "anotherOne"
+		parameters {
+		name = "test2.exe"
+		}
+		platform = "desktop.windows.all"
+	}
+	}`, rName)
 }
-data "appgate_mfa_provider" "fido" {
-  mfa_provider_name = "Default FIDO2 Provider"
-}
-resource "appgate_saml_identity_provider" "saml_test_resource" {
-  name = "%s"
 
-  admin_provider = true
-  ip_pool_v4     = data.appgate_ip_pool.ip_v4_pool.id
-  ip_pool_v6     = data.appgate_ip_pool.ip_v6_pool.id
-  dns_servers = [
-    "172.17.18.19",
-    "192.100.111.31",
-    "192.100.111.32",
-  ]
-  dns_search_domains = [
-    "internal.company.com"
-  ]
-  redirect_url = "https://saml.company.com"
-  issuer       = "http://adfs-test.company.com/adfs/services/trust"
-  audience     = "Company Appgate SDP"
-
-
-  provider_certificate = <<-EOF
------BEGIN CERTIFICATE-----
-MIICZjCCAc+gAwIBAgIUT0AsBLRI7aKjaMTnH1N9J6eS+7EwDQYJKoZIhvcNAQEL
-BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
-GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMDA5MjIxNDQ5MTZaFw0yMTA5
-MjIxNDQ5MTZaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
-HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwgZ8wDQYJKoZIhvcNAQEB
-BQADgY0AMIGJAoGBAOWp5CnfLvNpjeESzTg/B/1kG1BRdXtM00q59WPj7adZ5gq+
-+Hr0mWEQ5GldgmXRE3HsXfv7hiq4RwX9h+qtRinwhSvtLquM54/Fpw+TYZl5N27m
-ov8a04qqlo8c3BqXR5Vp+ohPVcXs2I21k5bUTh5XwHj4uiv8uxmKzk42WETbAgMB
-AAGjUzBRMB0GA1UdDgQWBBSpc1YN7rgPiBrVPn0roGV+1B4ETDAfBgNVHSMEGDAW
-gBSpc1YN7rgPiBrVPn0roGV+1B4ETDAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3
-DQEBCwUAA4GBAMgxxBlfgH98ME7Es9xlV3HrurwG1p2gBvrrEACMtFNgtZE1vgck
-jmhbc3t+Af9Dv9KBkaI6ZDl16uiptdpAv59wLgbVFgEPUJboRjhIaw5mPcMCeSDE
-eIE/AV/qHWNEiLIMP5JO2FUbjpDCYtHkCOFDmv01e6rs86L3MQ8zF76T
------END CERTIFICATE-----
-EOF
-
-  block_local_dns_requests = true
-  on_boarding_two_factor {
-    mfa_provider_id       = data.appgate_mfa_provider.fido.id
-    device_limit_per_user = 6
-    message               = "welcome"
+func testAccCheckSamlIdentityProviderClaimMoveAndDelete(rName string) string {
+	return fmt.Sprintf(`
+  data "appgate_ip_pools" "ip_v6_pool" {
+    ip_pool_name = "default pool v6"
   }
-  tags = [
-    "terraform",
-
-  ]
-  claim_mappings {
-    attribute_name = "objectGUID"
-    claim_name     = "userId"
-    encrypted      = false
-    list           = false
+  
+  data "appgate_ip_pools" "ip_v4_pool" {
+    ip_pool_name = "default pool v4"
   }
-  claim_mappings {
-    attribute_name = "sAMAccountName"
-    claim_name     = "username"
-    encrypted      = false
-    list           = false
+  data "appgate_mfa_provider" "fido" {
+    mfa_provider_name = "Default FIDO2 Provider"
   }
-  claim_mappings {
-    attribute_name = "givenName"
-    claim_name     = "firstName"
-    encrypted      = false
-    list           = false
-  }
-  claim_mappings {
-    attribute_name = "sn"
-    claim_name     = "lastName"
-    encrypted      = false
-    list           = false
-  }
-  claim_mappings {
-    attribute_name = "mail"
-    claim_name     = "emails"
-    encrypted      = false
-    list           = true
-  }
-  claim_mappings {
-    attribute_name = "memberOf"
-    claim_name     = "groups"
-    encrypted      = false
-    list           = true
-  }
-
-  on_demand_claim_mappings {
-    command    = "fileSize"
-    claim_name = "antiVirusIsRunning"
-    parameters {
-      path = "/usr/bin/python3"
+  resource "appgate_saml_identity_provider" "saml_test_resource" {
+    name = "%s"
+    notes = "Test note change"
+    admin_provider = false
+    ip_pool_v4     = data.appgate_ip_pools.ip_v4_pool.id
+    dns_servers = [
+      "192.100.111.32",
+      "172.17.18.20"
+    ]
+    dns_search_domains = [
+      "test.company.com"
+    ]
+    redirect_url = "https://saml.update.company.com"
+    issuer       = "http://adfs-test.update.company.com/adfs/services/trust"
+    audience     = "Company Appgate SDP - Update"
+  
+  
+    provider_certificate = <<-EOF
+  -----BEGIN CERTIFICATE-----
+  MIICZjCCAc+gAwIBAgIUT0AsBLRI7aKjaMTnH1N9J6eS+7EwDQYJKoZIhvcNAQEL
+  BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+  GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMDA5MjIxNDQ5MTZaFw0yMTA5
+  MjIxNDQ5MTZaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+  HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwgZ8wDQYJKoZIhvcNAQEB
+  BQADgY0AMIGJAoGBAOWp5CnfLvNpjeESzTg/B/1kG1BRdXtM00q59WPj7adZ5gq+
+  +Hr0mWEQ5GldgmXRE3HsXfv7hiq4RwX9h+qtRinwhSvtLquM54/Fpw+TYZl5N27m
+  ov8a04qqlo8c3BqXR5Vp+ohPVcXs2I21k5bUTh5XwHj4uiv8uxmKzk42WETbAgMB
+  AAGjUzBRMB0GA1UdDgQWBBSpc1YN7rgPiBrVPn0roGV+1B4ETDAfBgNVHSMEGDAW
+  gBSpc1YN7rgPiBrVPn0roGV+1B4ETDAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3
+  DQEBCwUAA4GBAMgxxBlfgH98ME7Es9xlV3HrurwG1p2gBvrrEACMtFNgtZE1vgck
+  jmhbc3t+Af9Dv9KBkaI6ZDl16uiptdpAv59wLgbVFgEPUJboRjhIaw5mPcMCeSDE
+  eIE/AV/qHWNEiLIMP5JO2FUbjpDCYtHkCOFDmv01e6rs86L3MQ8zF76T
+  -----END CERTIFICATE-----
+  EOF
+  
+    block_local_dns_requests = false
+    inactivity_timeout_minutes = 5
+    on_boarding_two_factor {
+      mfa_provider_id       = data.appgate_mfa_provider.fido.id
+      device_limit_per_user = 4
+      message               = "change"
     }
-    platform = "desktop.windows.all"
-  }
+
+    claim_mappings {
+      attribute_name = "sn"
+      claim_name     = "lastName"
+      encrypted      = false
+      list           = false
+    }
+    claim_mappings {
+      attribute_name = "sAMAccountName"
+      claim_name     = "username"
+      encrypted      = false
+      list           = false
+    }
+    claim_mappings {
+      attribute_name = "mail"
+      claim_name     = "emails"
+      encrypted      = false
+      list           = true
+    }
+      claim_mappings {
+      attribute_name = "test"
+      claim_name     = "test"
+      encrypted      = true
+      list           = false
+    }
+    claim_mappings {
+      attribute_name = "givenName"
+      claim_name     = "firstName"
+      encrypted      = false
+      list           = false
+    }
+    on_demand_claim_mappings {
+      command    = "serviceRunning"
+      claim_name = "anotherOne"
+      parameters {
+        name = "test2.exe"
+      }
+      platform = "desktop.windows.all"
+    }
+    on_demand_claim_mappings {
+      command    = "serviceRunning"
+      claim_name = "testing"
+      parameters {
+        name = "test.exe"
+      }
+      platform = "desktop.windows.all"
+    }
+    
+  }`, rName)
 }
-`, rName)
+
+func testAccCheckSamlIdentityProviderClaimMoves(rName string) string {
+	return fmt.Sprintf(`
+  data "appgate_ip_pools" "ip_v6_pool" {
+    ip_pool_name = "default pool v6"
+  }
+  
+  data "appgate_ip_pools" "ip_v4_pool" {
+    ip_pool_name = "default pool v4"
+  }
+  data "appgate_mfa_provider" "fido" {
+    mfa_provider_name = "Default FIDO2 Provider"
+  }
+  resource "appgate_saml_identity_provider" "saml_test_resource" {
+    name = "%s"
+    notes = "Test note change"
+    admin_provider = false
+    ip_pool_v4     = data.appgate_ip_pools.ip_v4_pool.id
+    dns_servers = [
+      "192.100.111.32",
+      "172.17.18.20"
+    ]
+    dns_search_domains = [
+      "test.company.com"
+    ]
+    redirect_url = "https://saml.update.company.com"
+    issuer       = "http://adfs-test.update.company.com/adfs/services/trust"
+    audience     = "Company Appgate SDP - Update"
+  
+  
+    provider_certificate = <<-EOF
+  -----BEGIN CERTIFICATE-----
+  MIICZjCCAc+gAwIBAgIUT0AsBLRI7aKjaMTnH1N9J6eS+7EwDQYJKoZIhvcNAQEL
+  BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+  GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMDA5MjIxNDQ5MTZaFw0yMTA5
+  MjIxNDQ5MTZaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+  HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwgZ8wDQYJKoZIhvcNAQEB
+  BQADgY0AMIGJAoGBAOWp5CnfLvNpjeESzTg/B/1kG1BRdXtM00q59WPj7adZ5gq+
+  +Hr0mWEQ5GldgmXRE3HsXfv7hiq4RwX9h+qtRinwhSvtLquM54/Fpw+TYZl5N27m
+  ov8a04qqlo8c3BqXR5Vp+ohPVcXs2I21k5bUTh5XwHj4uiv8uxmKzk42WETbAgMB
+  AAGjUzBRMB0GA1UdDgQWBBSpc1YN7rgPiBrVPn0roGV+1B4ETDAfBgNVHSMEGDAW
+  gBSpc1YN7rgPiBrVPn0roGV+1B4ETDAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3
+  DQEBCwUAA4GBAMgxxBlfgH98ME7Es9xlV3HrurwG1p2gBvrrEACMtFNgtZE1vgck
+  jmhbc3t+Af9Dv9KBkaI6ZDl16uiptdpAv59wLgbVFgEPUJboRjhIaw5mPcMCeSDE
+  eIE/AV/qHWNEiLIMP5JO2FUbjpDCYtHkCOFDmv01e6rs86L3MQ8zF76T
+  -----END CERTIFICATE-----
+  EOF
+  
+    block_local_dns_requests = false
+    inactivity_timeout_minutes = 5
+    on_boarding_two_factor {
+      mfa_provider_id       = data.appgate_mfa_provider.fido.id
+      device_limit_per_user = 4
+      message               = "change"
+    }
+	claim_mappings {
+		attribute_name = "mail"
+		claim_name     = "emails"
+		encrypted      = false
+		list           = true
+	  }
+	claim_mappings {
+		attribute_name = "test"
+		claim_name     = "test"
+		encrypted      = true
+		list           = false
+	}
+    claim_mappings {
+      attribute_name = "sn"
+      claim_name     = "lastName"
+      encrypted      = false
+      list           = false
+    }
+    claim_mappings {
+      attribute_name = "sAMAccountName"
+      claim_name     = "username"
+      encrypted      = false
+      list           = false
+    }
+    claim_mappings {
+      attribute_name = "givenName"
+      claim_name     = "firstName"
+      encrypted      = false
+      list           = false
+    }
+    on_demand_claim_mappings {
+      command    = "serviceRunning"
+      claim_name = "testing"
+      parameters {
+        name = "test.exe"
+      }
+      platform = "desktop.windows.all"
+    }
+    on_demand_claim_mappings {
+		command    = "serviceRunning"
+		claim_name = "anotherOne"
+		parameters {
+		  name = "test2.exe"
+		}
+		platform = "desktop.windows.all"
+	  }
+  }`, rName)
 }
 
 func testAccCheckSamlIdentityProviderExists(resource string) resource.TestCheckFunc {
+
 	return func(state *terraform.State) error {
 		token := testAccProvider.Meta().(*Client).Token
 		api := testAccProvider.Meta().(*Client).API.SamlIdentityProvidersApi
-
 		rs, ok := state.RootModule().Resources[resource]
+		fmt.Println(rs.Primary)
 		if !ok {
 			return fmt.Errorf("Not found: %s", resource)
 		}


### PR DESCRIPTION
Good Evening!

Few fixes:

- While using the saml idp resource, we noticed that if you changed the order of the claims (claim mapping or on-demand), TF would complain and try to update things... This is not good. Based on the API docs, these are arrays and doesn't specify that order maters. As such, the majority of the changes to the idp and saml idp files were related to changing the claims from "TypeList" to "TypeSet" so order would no longer matter. 
- We found a bug while testing "claim mappings" where the "encrypted" field wasn't being sent to the api or read back in right. 

Additionally, I enhanced the test file for SAML IDP so it is a bit more robust, testing creation, updates, and deletes. 

Let me know if there are any questions/comments you need me to address. 

Thank you,
Derek